### PR TITLE
募集作成時にPlanStatusの判定を作成

### DIFF
--- a/domain/plan.go
+++ b/domain/plan.go
@@ -17,6 +17,7 @@ type TPlanInsert struct {
 	MaxPeopleNumber int    `json:"max_people_number"`
 	MinPeopleNumber int    `json:"min_people_number"`
 	MeetTime        string `json:"meet_time"`
+	PlanStatus      int    `json:"status"`
 	OwnerUserId     int    `json:"owner_user_id"`
 }
 

--- a/interfaces/controllers/plan_controller.go
+++ b/interfaces/controllers/plan_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"CoopeLunch-api/domain"
 	"CoopeLunch-api/interfaces/database"
+	"CoopeLunch-api/tools"
 	"CoopeLunch-api/usecase"
 	"encoding/json"
 	"net/http"
@@ -54,6 +55,9 @@ func (controller *PlanController) PlanInsertView(w http.ResponseWriter, r *http.
 	if err != nil {
 		response(w, err, nil)
 		return
+	}
+	if plan.MinPeopleNumber == 1 {
+		plan.PlanStatus = tools.PLAN_STATUS["ESTABLISHED"]
 	}
 	id, err := controller.interactor.InsertPlan(plan)
 	if err != nil {

--- a/interfaces/database/plan_repository.go
+++ b/interfaces/database/plan_repository.go
@@ -59,8 +59,8 @@ func (repo *PlanRepository) GetByUserId(userId int) (plans []domain.TPlan, err e
 
 func (repo *PlanRepository) Insert(plan domain.TPlanInsert) (id int, err error) {
 	exe, err := repo.Execute(
-		"INSERT INTO plans(ShopName, MeetPlace, MaxPeopleNumber, MinPeopleNumber, MeetTime, OwnerUserId) VALUES(?, ?, ?, ?, ?, ?)",
-		plan.ShopName, plan.MeetPlace, plan.MaxPeopleNumber, plan.MinPeopleNumber, plan.MeetTime, plan.OwnerUserId,
+		"INSERT INTO plans(ShopName, MeetPlace, MaxPeopleNumber, MinPeopleNumber, MeetTime,  PlanStatus, OwnerUserId) VALUES(?, ?, ?, ?, ?, ?, ?)",
+		plan.ShopName, plan.MeetPlace, plan.MaxPeopleNumber, plan.MinPeopleNumber, plan.MeetTime, plan.PlanStatus, plan.OwnerUserId,
 	)
 	if err != nil {
 		return id, err

--- a/tools/constants.go
+++ b/tools/constants.go
@@ -1,0 +1,9 @@
+package tools
+
+var PLAN_STATUS = map[string]int{
+	"NOT_ESTABLISHED": 0,
+	"ESTABLISHED":     1,
+	"Filled":          2,
+	"END":             3,
+	"EXPIRED":         4,
+}


### PR DESCRIPTION
## 概要
募集作成時に、
最低人数を超えていた場合（最低人数が1人）に、募集のステータスを1（成立）に変更。

## 動作確認方法
1. 最低人数が１の場合のステータスが１であることの確認
2. 最低人数が２以上である時に、ステータスが０であることの確認